### PR TITLE
Add QR code generator page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -26,6 +26,9 @@ export default function Home() {
         <Link href="/passwordgenerator" className="text-xl text-blue-600 hover:underline">
           Password Generator
         </Link>
+        <Link href="/qrcode" className="text-xl text-blue-600 hover:underline">
+          QR Code Generator
+        </Link>
       </div>
     </div>
   );

--- a/app/qrcode/page.tsx
+++ b/app/qrcode/page.tsx
@@ -1,0 +1,60 @@
+'use client'
+
+import { useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export default function QRCodeGenerator() {
+  const [text, setText] = useState('')
+  const [qrUrl, setQrUrl] = useState('')
+
+  const handleGenerate = async () => {
+    if (!text) return
+    try {
+      const QRCode = await import('qrcode')
+      const url = await QRCode.toDataURL(text)
+      setQrUrl(url)
+    } catch (err) {
+      console.error(err)
+    }
+  }
+
+  const handleDownload = () => {
+    if (!qrUrl) return
+    const link = document.createElement('a')
+    link.href = qrUrl
+    link.download = 'qrcode.png'
+    link.click()
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <Card className="w-full max-w-md m-auto">
+        <CardHeader>
+          <CardTitle>QR Code Generator</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="space-y-4">
+            <Input
+              placeholder="Enter text or URL"
+              value={text}
+              onChange={(e) => setText(e.target.value)}
+            />
+            <Button onClick={handleGenerate} disabled={!text}>
+              Generate
+            </Button>
+            {qrUrl && (
+              <div className="flex flex-col items-center space-y-2">
+                <img src={qrUrl} alt="QR Code" className="h-40 w-40" />
+                <Button variant="outline" onClick={handleDownload}>
+                  Download
+                </Button>
+              </div>
+            )}
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.5.4",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "qrcode": "^1.5.3"
   },
   "devDependencies": {
     "@types/diff": "^5.2.3",


### PR DESCRIPTION
## Summary
- add new `/qrcode` route for creating QR codes
- link QR code generator from home page
- include `qrcode` dependency

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_682d6090b3a48332aa10bfdca669ebaa