### PR TITLE
Add JSON formatter tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,12 @@ Live Demo - https://snaptools.netlify.app/
   - Input birthdate to calculate exact age.
   - Display age in years, months, and days.
 
+### JSON Formatter/Validator
+- **Description**: Quickly format and validate JSON data in the browser.
+- **Features**:
+  - Paste JSON text to format it with proper indentation.
+  - Validation feedback if the input is not valid JSON.
+
 ## Getting Started
 
 To get a local copy up and running, follow these simple steps.

--- a/app/jsonformatter/page.tsx
+++ b/app/jsonformatter/page.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import { useState } from 'react'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export default function JSONFormatter() {
+  const [input, setInput] = useState('')
+  const [output, setOutput] = useState('')
+  const [error, setError] = useState('')
+
+  const handleFormat = () => {
+    try {
+      const parsed = JSON.parse(input)
+      const formatted = JSON.stringify(parsed, null, 2)
+      setOutput(formatted)
+      setError('')
+    } catch (err) {
+      setError('Invalid JSON')
+      setOutput('')
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <Card className="w-full max-w-2xl">
+        <CardHeader>
+          <CardTitle>JSON Formatter / Validator</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            placeholder="Paste JSON here"
+            rows={10}
+            className="font-mono"
+          />
+          <Button onClick={handleFormat} className="w-full">
+            Format JSON
+          </Button>
+          {error && <p className="text-red-500">{error}</p>}
+          {output && (
+            <Textarea
+              value={output}
+              readOnly
+              rows={10}
+              className="font-mono"
+            />
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,6 +29,9 @@ export default function Home() {
         <Link href="/qrcode" className="text-xl text-blue-600 hover:underline">
           QR Code Generator
         </Link>
+        <Link href="/jsonformatter" className="text-xl text-blue-600 hover:underline">
+          JSON Formatter/Validator
+        </Link>
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- add `/jsonformatter` route with JSON formatting/validation feature
- link JSON Formatter from the homepage
- document the new tool in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_682d564c503c8332a6ad4b3ee5fb1098