### PR TITLE
Add Base64 encoder/decoder tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,12 @@ Live Demo - https://snaptools.netlify.app/
   - Paste JSON text to format it with proper indentation.
   - Validation feedback if the input is not valid JSON.
 
+### Base64 Encoder/Decoder
+- **Description**: Encode text to Base64 and decode Base64 strings.
+- **Features**:
+  - Convert plain text into Base64.
+  - Decode Base64 back to human-readable text.
+
 ## Getting Started
 
 To get a local copy up and running, follow these simple steps.

--- a/app/base64/page.tsx
+++ b/app/base64/page.tsx
@@ -1,0 +1,63 @@
+'use client'
+
+import { useState } from 'react'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+
+export default function Base64Tool() {
+  const [text, setText] = useState('')
+  const [base64, setBase64] = useState('')
+  const [error, setError] = useState('')
+
+  const encode = () => {
+    try {
+      setBase64(btoa(text))
+      setError('')
+    } catch {
+      setError('Unable to encode input')
+    }
+  }
+
+  const decode = () => {
+    try {
+      setText(atob(base64))
+      setError('')
+    } catch {
+      setError('Invalid Base64 string')
+    }
+  }
+
+  return (
+    <div className="flex items-center justify-center min-h-screen">
+      <Card className="w-full max-w-xl">
+        <CardHeader>
+          <CardTitle>Base64 Encoder / Decoder</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Textarea
+            value={text}
+            onChange={(e) => setText(e.target.value)}
+            placeholder="Text"
+            rows={5}
+            className="font-mono"
+          />
+          <Button onClick={encode} disabled={!text} className="w-full">
+            Encode
+          </Button>
+          <Textarea
+            value={base64}
+            onChange={(e) => setBase64(e.target.value)}
+            placeholder="Base64"
+            rows={5}
+            className="font-mono"
+          />
+          <Button onClick={decode} disabled={!base64} className="w-full">
+            Decode
+          </Button>
+          {error && <p className="text-red-500">{error}</p>}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -29,6 +29,9 @@ export default function Home() {
         <Link href="/qrcode" className="text-xl text-blue-600 hover:underline">
           QR Code Generator
         </Link>
+        <Link href="/base64" className="text-xl text-blue-600 hover:underline">
+          Base64 Encoder/Decoder
+        </Link>
         <Link href="/jsonformatter" className="text-xl text-blue-600 hover:underline">
           JSON Formatter/Validator
         </Link>


### PR DESCRIPTION
## Summary
- implement a Base64 encoder/decoder page
- link to new page from the home page
- document the tool in README

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e9bc959b88332bc863e18798f969b