### PR TITLE
Add home navigation links

### DIFF
--- a/app/agecalculator/page.tsx
+++ b/app/agecalculator/page.tsx
@@ -9,6 +9,7 @@ import { Input } from "@/components/ui/input"
 import { Label } from "@/components/ui/label"
 import { Popover, PopoverContent, PopoverTrigger } from "@/components/ui/popover"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
+import Link from 'next/link'
 
 export default function Component() {
   const [birthDate, setBirthDate] = useState<Date | undefined>(undefined)
@@ -65,7 +66,7 @@ export default function Component() {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen">
+    <div className="flex flex-col items-center justify-center min-h-screen">
       <Card className="w-full max-w-lg">
         <CardHeader>
           <CardTitle>Precise Age Calculator</CardTitle>
@@ -135,6 +136,9 @@ export default function Component() {
           </div>
         </CardContent>
       </Card>
+      <Link href="/" className="mt-4 text-blue-600 hover:underline">
+        Back to Home
+      </Link>
     </div>
   )
 }

--- a/app/agecalculator/page.tsx
+++ b/app/agecalculator/page.tsx
@@ -67,6 +67,12 @@ export default function Component() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen">
+      <Link
+        href="/"
+        className="fixed top-4 left-4 text-blue-600 hover:underline"
+      >
+        Back to Home
+      </Link>
       <Card className="w-full max-w-lg">
         <CardHeader>
           <CardTitle>Precise Age Calculator</CardTitle>
@@ -136,9 +142,6 @@ export default function Component() {
           </div>
         </CardContent>
       </Card>
-      <Link href="/" className="mt-4 text-blue-600 hover:underline">
-        Back to Home
-      </Link>
     </div>
   )
 }

--- a/app/calculator/page.tsx
+++ b/app/calculator/page.tsx
@@ -6,6 +6,7 @@ import { Input } from "@/components/ui/input"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select"
 import { ScrollArea } from "@/components/ui/scroll-area"
+import Link from 'next/link'
 
 type CalculationType = 'standard' | 'length' | 'weight' | 'temperature'
 
@@ -288,6 +289,11 @@ export default function AdvancedCalculator() {
             <div key={index} className="text-sm mb-1">{item}</div>
           ))}
         </ScrollArea>
+      </div>
+      <div className="text-center mt-4">
+        <Link href="/" className="text-blue-600 hover:underline">
+          Back to Home
+        </Link>
       </div>
     </div>
   )

--- a/app/calculator/page.tsx
+++ b/app/calculator/page.tsx
@@ -170,6 +170,12 @@ export default function AdvancedCalculator() {
 
   return (
     <div className="w-full max-w-md mx-auto p-4 bg-background rounded-lg shadow-lg">
+      <Link
+        href="/"
+        className="fixed top-4 left-4 text-blue-600 hover:underline"
+      >
+        Back to Home
+      </Link>
       <Tabs value={activeTab} onValueChange={(value) => setActiveTab(value as CalculationType)} className="w-full">
         <TabsList className="grid w-full grid-cols-4 mb-4">
           <TabsTrigger value="standard">Standard</TabsTrigger>
@@ -289,11 +295,6 @@ export default function AdvancedCalculator() {
             <div key={index} className="text-sm mb-1">{item}</div>
           ))}
         </ScrollArea>
-      </div>
-      <div className="text-center mt-4">
-        <Link href="/" className="text-blue-600 hover:underline">
-          Back to Home
-        </Link>
       </div>
     </div>
   )

--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -6,6 +6,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs"
 import { Input } from "@/components/ui/input"
 import { X } from "lucide-react"
+import Link from 'next/link'
 
 const ScrollableInput = ({ value, onChange, max }) => {
   return (
@@ -143,7 +144,7 @@ export default function ClockTimerStopwatchWorldClock() {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen">
+    <div className="flex flex-col items-center justify-center min-h-screen">
       <Card className="w-full max-w-md mx-auto">
         <CardHeader>
           <CardTitle className="text-2xl font-bold text-center">Timer, Stopwatch & World Clock</CardTitle>
@@ -241,6 +242,9 @@ export default function ClockTimerStopwatchWorldClock() {
           </Tabs>
         </CardContent>
       </Card>
+      <Link href="/" className="mt-4 text-blue-600 hover:underline">
+        Back to Home
+      </Link>
     </div>
   )
 }

--- a/app/clock/page.tsx
+++ b/app/clock/page.tsx
@@ -145,6 +145,12 @@ export default function ClockTimerStopwatchWorldClock() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen">
+      <Link
+        href="/"
+        className="fixed top-4 left-4 text-blue-600 hover:underline"
+      >
+        Back to Home
+      </Link>
       <Card className="w-full max-w-md mx-auto">
         <CardHeader>
           <CardTitle className="text-2xl font-bold text-center">Timer, Stopwatch & World Clock</CardTitle>
@@ -242,9 +248,6 @@ export default function ClockTimerStopwatchWorldClock() {
           </Tabs>
         </CardContent>
       </Card>
-      <Link href="/" className="mt-4 text-blue-600 hover:underline">
-        Back to Home
-      </Link>
     </div>
   )
 }

--- a/app/cronparser/page.tsx
+++ b/app/cronparser/page.tsx
@@ -7,6 +7,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert"
 import { InfoIcon } from 'lucide-react'
 import { parseExpression } from 'cron-parser'
+import Link from 'next/link'
 
 
 // Note: In a real-world scenario, you'd install cron-parser via npm.
@@ -66,7 +67,7 @@ export default function CronExplainer() {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen">
+    <div className="flex flex-col items-center justify-center min-h-screen">
         <Card className="w-full max-w-2xl m-auto">
         <CardHeader>
             <CardTitle>Cron Expression Explainer</CardTitle>
@@ -108,6 +109,9 @@ export default function CronExplainer() {
             </div>
         </CardContent>
         </Card>
+        <Link href="/" className="mt-4 text-blue-600 hover:underline">
+          Back to Home
+        </Link>
     </div>
   )
 }

--- a/app/cronparser/page.tsx
+++ b/app/cronparser/page.tsx
@@ -68,6 +68,12 @@ export default function CronExplainer() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen">
+        <Link
+          href="/"
+          className="fixed top-4 left-4 text-blue-600 hover:underline"
+        >
+          Back to Home
+        </Link>
         <Card className="w-full max-w-2xl m-auto">
         <CardHeader>
             <CardTitle>Cron Expression Explainer</CardTitle>
@@ -109,9 +115,6 @@ export default function CronExplainer() {
             </div>
         </CardContent>
         </Card>
-        <Link href="/" className="mt-4 text-blue-600 hover:underline">
-          Back to Home
-        </Link>
     </div>
   )
 }

--- a/app/csveditor/page.tsx
+++ b/app/csveditor/page.tsx
@@ -6,6 +6,7 @@ import { Button } from "@/components/ui/button"
 import { Input } from "@/components/ui/input"
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table"
 import { Trash2, Plus, ArrowUp, ArrowDown, ArrowUpDown, Search } from 'lucide-react'
+import Link from 'next/link'
 
 type SortConfig = {
   key: number;
@@ -225,6 +226,11 @@ export default function CSVEditor() {
           </Table>
         </div>
       )}
+      <div className="text-center mt-4">
+        <Link href="/" className="text-blue-600 hover:underline">
+          Back to Home
+        </Link>
+      </div>
     </div>
   )
 }

--- a/app/csveditor/page.tsx
+++ b/app/csveditor/page.tsx
@@ -131,6 +131,12 @@ export default function CSVEditor() {
 
   return (
     <div className="max-w-[90%] mx-auto p-4 bg-background">
+      <Link
+        href="/"
+        className="fixed top-4 left-4 text-blue-600 hover:underline"
+      >
+        Back to Home
+      </Link>
       <h1 className="text-2xl font-bold mb-4">CSV Editor</h1>
       <div className="flex flex-wrap gap-4 mb-4">
         <Button onClick={handleFileImport}>Import CSV</Button>
@@ -226,11 +232,6 @@ export default function CSVEditor() {
           </Table>
         </div>
       )}
-      <div className="text-center mt-4">
-        <Link href="/" className="text-blue-600 hover:underline">
-          Back to Home
-        </Link>
-      </div>
     </div>
   )
 }

--- a/app/diff/page.tsx
+++ b/app/diff/page.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button"
 import { ScrollArea } from "@/components/ui/scroll-area"
 import { Textarea } from "@/components/ui/textarea"
 import * as diff from 'diff'
+import Link from 'next/link'
 
 export default function DiffApp() {
   const [leftText, setLeftText] = useState('')
@@ -101,6 +102,11 @@ export default function DiffApp() {
             </div>
           </ScrollArea>
         </div>
+      </div>
+      <div className="text-center mt-4">
+        <Link href="/" className="text-blue-600 hover:underline">
+          Back to Home
+        </Link>
       </div>
     </div>
   )

--- a/app/diff/page.tsx
+++ b/app/diff/page.tsx
@@ -73,6 +73,12 @@ export default function DiffApp() {
 
   return (
     <div className="container mx-auto p-4">
+      <Link
+        href="/"
+        className="fixed top-4 left-4 text-blue-600 hover:underline"
+      >
+        Back to Home
+      </Link>
       <div className="grid grid-cols-2 gap-4">
         <div>
           <Textarea
@@ -102,11 +108,6 @@ export default function DiffApp() {
             </div>
           </ScrollArea>
         </div>
-      </div>
-      <div className="text-center mt-4">
-        <Link href="/" className="text-blue-600 hover:underline">
-          Back to Home
-        </Link>
       </div>
     </div>
   )

--- a/app/jsonformatter/page.tsx
+++ b/app/jsonformatter/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Textarea } from '@/components/ui/textarea'
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import Link from 'next/link'
 
 export default function JSONFormatter() {
   const [input, setInput] = useState('')
@@ -23,7 +24,7 @@ export default function JSONFormatter() {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen">
+    <div className="flex flex-col items-center justify-center min-h-screen">
       <Card className="w-full max-w-2xl">
         <CardHeader>
           <CardTitle>JSON Formatter / Validator</CardTitle>
@@ -50,6 +51,9 @@ export default function JSONFormatter() {
           )}
         </CardContent>
       </Card>
+      <Link href="/" className="mt-4 text-blue-600 hover:underline">
+        Back to Home
+      </Link>
     </div>
   )
 }

--- a/app/jsonformatter/page.tsx
+++ b/app/jsonformatter/page.tsx
@@ -25,6 +25,12 @@ export default function JSONFormatter() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen">
+      <Link
+        href="/"
+        className="fixed top-4 left-4 text-blue-600 hover:underline"
+      >
+        Back to Home
+      </Link>
       <Card className="w-full max-w-2xl">
         <CardHeader>
           <CardTitle>JSON Formatter / Validator</CardTitle>
@@ -51,9 +57,6 @@ export default function JSONFormatter() {
           )}
         </CardContent>
       </Card>
-      <Link href="/" className="mt-4 text-blue-600 hover:underline">
-        Back to Home
-      </Link>
     </div>
   )
 }

--- a/app/passwordgenerator/page.tsx
+++ b/app/passwordgenerator/page.tsx
@@ -58,6 +58,12 @@ export default function PasswordGenerator() {
 
   return (
     <div className="min-h-screen flex flex-col items-center justify-center bg-gray-100 dark:bg-gray-900">
+      <Link
+        href="/"
+        className="fixed top-4 left-4 text-blue-600 hover:underline"
+      >
+        Back to Home
+      </Link>
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl font-bold text-center">Password Generator</CardTitle>
@@ -128,9 +134,6 @@ export default function PasswordGenerator() {
           </Button>
         </CardContent>
       </Card>
-      <Link href="/" className="mt-4 text-blue-600 hover:underline">
-        Back to Home
-      </Link>
     </div>
   )
 }

--- a/app/passwordgenerator/page.tsx
+++ b/app/passwordgenerator/page.tsx
@@ -7,6 +7,7 @@ import { Button } from "@/components/ui/button"
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card"
 import { Label } from "@/components/ui/label"
 import { Copy } from 'lucide-react'
+import Link from 'next/link'
 
 export default function PasswordGenerator() {
   const [password, setPassword] = useState('')
@@ -56,7 +57,7 @@ export default function PasswordGenerator() {
   }, [password])
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900">
+    <div className="min-h-screen flex flex-col items-center justify-center bg-gray-100 dark:bg-gray-900">
       <Card className="w-full max-w-md">
         <CardHeader>
           <CardTitle className="text-2xl font-bold text-center">Password Generator</CardTitle>
@@ -127,6 +128,9 @@ export default function PasswordGenerator() {
           </Button>
         </CardContent>
       </Card>
+      <Link href="/" className="mt-4 text-blue-600 hover:underline">
+        Back to Home
+      </Link>
     </div>
   )
 }

--- a/app/qrcode/page.tsx
+++ b/app/qrcode/page.tsx
@@ -31,6 +31,12 @@ export default function QRCodeGenerator() {
 
   return (
     <div className="flex flex-col items-center justify-center min-h-screen">
+      <Link
+        href="/"
+        className="fixed top-4 left-4 text-blue-600 hover:underline"
+      >
+        Back to Home
+      </Link>
       <Card className="w-full max-w-md m-auto">
         <CardHeader>
           <CardTitle>QR Code Generator</CardTitle>
@@ -56,9 +62,6 @@ export default function QRCodeGenerator() {
           </div>
         </CardContent>
       </Card>
-      <Link href="/" className="mt-4 text-blue-600 hover:underline">
-        Back to Home
-      </Link>
     </div>
   )
 }

--- a/app/qrcode/page.tsx
+++ b/app/qrcode/page.tsx
@@ -4,6 +4,7 @@ import { useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { Input } from '@/components/ui/input'
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import Link from 'next/link'
 
 export default function QRCodeGenerator() {
   const [text, setText] = useState('')
@@ -29,7 +30,7 @@ export default function QRCodeGenerator() {
   }
 
   return (
-    <div className="flex items-center justify-center min-h-screen">
+    <div className="flex flex-col items-center justify-center min-h-screen">
       <Card className="w-full max-w-md m-auto">
         <CardHeader>
           <CardTitle>QR Code Generator</CardTitle>
@@ -55,6 +56,9 @@ export default function QRCodeGenerator() {
           </div>
         </CardContent>
       </Card>
+      <Link href="/" className="mt-4 text-blue-600 hover:underline">
+        Back to Home
+      </Link>
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- add Next.js `Link` to each tool page
- provide a back to Home link on every tool screen

## Testing
- `npm run lint` *(fails: `next` not found)*

------
https://chatgpt.com/codex/tasks/task_b_683e9bf8178c8332980335b4c5da09b3