### PR TITLE
Add converters, contrast tool and password meter

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,30 @@ Live Demo - https://snaptools.netlify.app/
   - Live preview while typing.
   - Supports common Markdown formatting like headings, lists and links.
 
+### CSV ↔ JSON Converter
+- **Description**: Quickly convert between CSV and JSON formats.
+- **Features**:
+  - Convert CSV to JSON.
+  - Convert JSON to CSV.
+
+### JSON ↔ YAML Converter
+- **Description**: Convert data between JSON and YAML formats.
+- **Features**:
+  - Convert JSON to YAML.
+  - Convert YAML to JSON.
+
+### Color Contrast Checker
+- **Description**: Test color combinations for accessibility compliance.
+- **Features**:
+  - Enter foreground and background colors.
+  - See contrast ratio and WCAG results.
+
+### Password Strength Meter
+- **Description**: Evaluate the strength of a user-supplied password.
+- **Features**:
+  - Visual strength meter.
+  - Tips for creating stronger passwords.
+
 ## Getting Started
 
 To get a local copy up and running, follow these simple steps.

--- a/app/colorcontrast/page.tsx
+++ b/app/colorcontrast/page.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import Link from 'next/link'
+
+function hexToRgb(hex: string) {
+  let cleaned = hex.replace('#', '')
+  if (cleaned.length === 3) {
+    cleaned = cleaned.split('').map(c => c + c).join('')
+  }
+  const num = parseInt(cleaned, 16)
+  return { r: (num >> 16) & 255, g: (num >> 8) & 255, b: num & 255 }
+}
+
+function luminance(r: number, g: number, b: number) {
+  const a = [r, g, b].map(v => {
+    v /= 255
+    return v <= 0.03928 ? v / 12.92 : Math.pow((v + 0.055) / 1.055, 2.4)
+  })
+  return 0.2126 * a[0] + 0.7152 * a[1] + 0.0722 * a[2]
+}
+
+function contrastRatio(c1: string, c2: string) {
+  const rgb1 = hexToRgb(c1)
+  const rgb2 = hexToRgb(c2)
+  const l1 = luminance(rgb1.r, rgb1.g, rgb1.b)
+  const l2 = luminance(rgb2.r, rgb2.g, rgb2.b)
+  return (Math.max(l1, l2) + 0.05) / (Math.min(l1, l2) + 0.05)
+}
+
+export default function ColorContrastChecker() {
+  const [foreground, setForeground] = useState('#000000')
+  const [background, setBackground] = useState('#ffffff')
+
+  const ratio = contrastRatio(foreground, background)
+  const passesAA = ratio >= 4.5
+  const passesAAA = ratio >= 7
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4 space-y-4">
+      <Link href="/" className="fixed top-4 left-4 text-blue-600 hover:underline">
+        Back to Home
+      </Link>
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Color Contrast Checker</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="flex space-x-4">
+            <div className="space-y-2 flex-1">
+              <label className="block text-sm font-medium" htmlFor="foreground">Foreground</label>
+              <Input id="foreground" type="color" value={foreground} onChange={e => setForeground(e.target.value)} />
+            </div>
+            <div className="space-y-2 flex-1">
+              <label className="block text-sm font-medium" htmlFor="background">Background</label>
+              <Input id="background" type="color" value={background} onChange={e => setBackground(e.target.value)} />
+            </div>
+          </div>
+          <div className="h-20 flex items-center justify-center rounded" style={{background, color: foreground}}>
+            Sample Text
+          </div>
+          <p>Contrast Ratio: {ratio.toFixed(2)}</p>
+          <p className={passesAA ? 'text-green-600' : 'text-red-600'}>AA: {passesAA ? 'Pass' : 'Fail'}</p>
+          <p className={passesAAA ? 'text-green-600' : 'text-red-600'}>AAA: {passesAAA ? 'Pass' : 'Fail'}</p>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/csvjson/page.tsx
+++ b/app/csvjson/page.tsx
@@ -1,0 +1,71 @@
+'use client'
+
+import { useState } from 'react'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import Papa from 'papaparse'
+import Link from 'next/link'
+
+export default function CsvJsonConverter() {
+  const [csvInput, setCsvInput] = useState('')
+  const [jsonInput, setJsonInput] = useState('')
+  const [error, setError] = useState('')
+
+  const csvToJson = () => {
+    try {
+      const result = Papa.parse(csvInput.trim(), { header: true })
+      setJsonInput(JSON.stringify(result.data, null, 2))
+      setError('')
+    } catch (err) {
+      setError('Invalid CSV input')
+    }
+  }
+
+  const jsonToCsv = () => {
+    try {
+      const data = JSON.parse(jsonInput)
+      const csv = Papa.unparse(data)
+      setCsvInput(csv)
+      setError('')
+    } catch (err) {
+      setError('Invalid JSON input')
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <Link href="/" className="fixed top-4 left-4 text-blue-600 hover:underline">
+        Back to Home
+      </Link>
+      <Card className="w-full max-w-2xl">
+        <CardHeader>
+          <CardTitle>CSV ↔ JSON Converter</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Textarea
+            value={csvInput}
+            onChange={(e) => setCsvInput(e.target.value)}
+            placeholder="CSV"
+            rows={6}
+            className="font-mono"
+          />
+          <Button onClick={csvToJson} disabled={!csvInput} className="w-full">
+            Convert to JSON
+          </Button>
+          <Textarea
+            value={jsonInput}
+            onChange={(e) => setJsonInput(e.target.value)}
+            placeholder="JSON"
+            rows={6}
+            className="font-mono"
+          />
+          <Button onClick={jsonToCsv} disabled={!jsonInput} className="w-full">
+            Convert to CSV
+          </Button>
+          {error && <p className="text-red-500">{error}</p>}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/jsonyaml/page.tsx
+++ b/app/jsonyaml/page.tsx
@@ -1,0 +1,70 @@
+'use client'
+
+import { useState } from 'react'
+import { Textarea } from '@/components/ui/textarea'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import yaml from 'js-yaml'
+import Link from 'next/link'
+
+export default function JsonYamlConverter() {
+  const [jsonInput, setJsonInput] = useState('')
+  const [yamlInput, setYamlInput] = useState('')
+  const [error, setError] = useState('')
+
+  const jsonToYaml = () => {
+    try {
+      const obj = JSON.parse(jsonInput)
+      setYamlInput(yaml.dump(obj))
+      setError('')
+    } catch {
+      setError('Invalid JSON input')
+    }
+  }
+
+  const yamlToJson = () => {
+    try {
+      const obj = yaml.load(yamlInput)
+      setJsonInput(JSON.stringify(obj, null, 2))
+      setError('')
+    } catch {
+      setError('Invalid YAML input')
+    }
+  }
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen">
+      <Link href="/" className="fixed top-4 left-4 text-blue-600 hover:underline">
+        Back to Home
+      </Link>
+      <Card className="w-full max-w-2xl">
+        <CardHeader>
+          <CardTitle>JSON ↔ YAML Converter</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Textarea
+            value={jsonInput}
+            onChange={(e) => setJsonInput(e.target.value)}
+            placeholder="JSON"
+            rows={6}
+            className="font-mono"
+          />
+          <Button onClick={jsonToYaml} disabled={!jsonInput} className="w-full">
+            Convert to YAML
+          </Button>
+          <Textarea
+            value={yamlInput}
+            onChange={(e) => setYamlInput(e.target.value)}
+            placeholder="YAML"
+            rows={6}
+            className="font-mono"
+          />
+          <Button onClick={yamlToJson} disabled={!yamlInput} className="w-full">
+            Convert to JSON
+          </Button>
+          {error && <p className="text-red-500">{error}</p>}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -11,6 +11,12 @@ export default function Home() {
         <Link href="/csveditor" className="text-xl text-blue-600 hover:underline">
           CSV Editor
         </Link>
+        <Link href="/csvjson" className="text-xl text-blue-600 hover:underline">
+          CSV ↔ JSON Converter
+        </Link>
+        <Link href="/jsonyaml" className="text-xl text-blue-600 hover:underline">
+          JSON ↔ YAML Converter
+        </Link>
         <Link href="/cronparser" className="text-xl text-blue-600 hover:underline">
           Cron Parser
         </Link>
@@ -26,6 +32,9 @@ export default function Home() {
         <Link href="/passwordgenerator" className="text-xl text-blue-600 hover:underline">
           Password Generator
         </Link>
+        <Link href="/passwordstrength" className="text-xl text-blue-600 hover:underline">
+          Password Strength Meter
+        </Link>
         <Link href="/qrcode" className="text-xl text-blue-600 hover:underline">
           QR Code Generator
         </Link>
@@ -37,6 +46,9 @@ export default function Home() {
         </Link>
         <Link href="/color" className="text-xl text-blue-600 hover:underline">
           Color Picker / Converter
+        </Link>
+        <Link href="/colorcontrast" className="text-xl text-blue-600 hover:underline">
+          Color Contrast Checker
         </Link>
         <Link href="/markdown" className="text-xl text-blue-600 hover:underline">
           Markdown Previewer

--- a/app/passwordstrength/page.tsx
+++ b/app/passwordstrength/page.tsx
@@ -1,0 +1,45 @@
+'use client'
+
+import { useState } from 'react'
+import { Input } from '@/components/ui/input'
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card'
+import zxcvbn from 'zxcvbn'
+import Link from 'next/link'
+
+const strengthLabels = ['Very Weak', 'Weak', 'Fair', 'Strong', 'Very Strong']
+
+export default function PasswordStrengthMeter() {
+  const [password, setPassword] = useState('')
+  const result = zxcvbn(password)
+  const score = result.score
+  const feedback = result.feedback.suggestions.join(' ')
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen p-4 space-y-4">
+      <Link href="/" className="fixed top-4 left-4 text-blue-600 hover:underline">
+        Back to Home
+      </Link>
+      <Card className="w-full max-w-md">
+        <CardHeader>
+          <CardTitle>Password Strength Meter</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <Input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            placeholder="Enter password"
+          />
+          <div className="h-2 bg-gray-200 rounded">
+            <div
+              className={`h-2 rounded ${score <= 1 ? 'bg-red-500' : score === 2 ? 'bg-yellow-500' : score === 3 ? 'bg-blue-500' : 'bg-green-600'}`}
+              style={{ width: `${((score + 1) / 5) * 100}%` }}
+            />
+          </div>
+          <p>{strengthLabels[score]}</p>
+          {feedback && <p className="text-sm text-gray-500">{feedback}</p>}
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "cron-parser": "^4.9.0",
         "date-fns": "^3.6.0",
         "diff": "^7.0.0",
+        "js-yaml": "^4.1.0",
         "lucide-react": "^0.453.0",
         "next": "^14.2.29",
         "papaparse": "^5.4.1",
@@ -31,7 +32,8 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "tailwind-merge": "^2.5.4",
-        "tailwindcss-animate": "^1.0.7"
+        "tailwindcss-animate": "^1.0.7",
+        "zxcvbn": "^4.4.2"
       },
       "devDependencies": {
         "@types/diff": "^5.2.3",
@@ -1802,7 +1804,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-hidden": {
@@ -3953,7 +3954,6 @@
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
       "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -6344,6 +6344,12 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/zxcvbn": {
+      "version": "4.4.2",
+      "resolved": "https://registry.npmjs.org/zxcvbn/-/zxcvbn-4.4.2.tgz",
+      "integrity": "sha512-Bq0B+ixT/DMyG8kgX2xWcI5jUvCwqrMxSFam7m0lAf78nf04hv6lNCsyLYdyYTrCVMqNDY/206K7eExYCeSyUQ==",
+      "license": "MIT"
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "cron-parser": "^4.9.0",
     "date-fns": "^3.6.0",
     "diff": "^7.0.0",
+    "js-yaml": "^4.1.0",
     "lucide-react": "^0.453.0",
     "next": "^14.2.29",
     "papaparse": "^5.4.1",
@@ -33,7 +34,8 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "tailwind-merge": "^2.5.4",
-    "tailwindcss-animate": "^1.0.7"
+    "tailwindcss-animate": "^1.0.7",
+    "zxcvbn": "^4.4.2"
   },
   "devDependencies": {
     "@types/diff": "^5.2.3",


### PR DESCRIPTION
## Summary
- add CSV/JSON converter page
- add JSON/YAML converter page
- add color contrast checker
- add password strength meter
- link new tools on the homepage
- document the new tools in README
- install `js-yaml` and `zxcvbn` dependencies

## Testing
- `npm run lint` *(fails: 13 errors, 363 warnings)*

------
https://chatgpt.com/codex/tasks/task_b_6849450c8c5c833294039a9f373ff91b